### PR TITLE
Improved MSSQL support

### DIFF
--- a/bin/sequelize-auto
+++ b/bin/sequelize-auto
@@ -23,7 +23,7 @@ var argv = require('optimist')
   .describe('p', 'Port number for database.')
   .describe('c', 'JSON file for Sequelize\'s constructor "options" flag object as defined here: https://sequelize.readthedocs.org/en/latest/api/sequelize/')
   .describe('o', 'What directory to place the models.')
-  .describe('e', 'The dialect/engine that you\'re using: postgres, mysql, sqlite')
+  .describe('e', 'The dialect/engine that you\'re using: postgres, mysql, sqlite, mssql')
   .describe('a', 'Path to a json file containing model definitions (for all tables) which are to be defined within a model\'s configuration parameter. For more info: https://sequelize.readthedocs.org/en/latest/docs/models-definition/#configuration')
   .describe('t', 'Comma-separated names of tables to import')
   .argv;
@@ -55,6 +55,9 @@ configFile.port = argv.p || configFile.port || 3306;
 configFile.host = argv.h || configFile.host || 'localhost';
 configFile.storage = argv.d;
 configFile.tables = configFile.tables || (argv.t && argv.t.split(',')) || null;
+
+if (configFile.dialect.toLowerCase() === 'mssql' && config.port === 3306)
+    configFile.port = 1433; // default port for MSSQL Server is 1433, not 3306
 
 var auto = new sequelizeAuto(argv.d, argv.u, (!! argv.x ? ('' + argv.x) : null), configFile);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,6 +168,10 @@ AutoSequelize.prototype.run = function(callback) {
             text[table] += spaces + spaces + spaces + attr + ": " + self.tables[table][field][attr];
           }
           else if (attr === "defaultValue") {
+            if ( self.dialect == 'mssql' &&  defaultVal.toLowerCase() === '(newid())' ) {
+              defaultVal = null; // disable adding "default value" attribute for UUID fields if generating for MS SQL
+            }  
+
             var val_text = defaultVal;
 
             if (isSerialKey) return true
@@ -234,7 +238,7 @@ AutoSequelize.prototype.run = function(callback) {
             else if (_attr.match(/^(float8|double precision)/)) {
               val = 'DataTypes.DOUBLE';
             }
-            else if (_attr.match(/^uuid/)) {
+            else if (_attr.match(/^uuid|uniqueidentifier/)) {
               val = 'DataTypes.UUIDV4';
             }
             else if (_attr.match(/^json/)) {


### PR DESCRIPTION
- proper handling of 'uniqueidentifier' field type for MS SQL by mapping it to UUIDV4 attribute type of model.
- defaultValue attribute: disable auto-generating of new value for UUID field by MSSQL server's function NEWID()
- adding default port 1433 for 'mssql' dialect for «-p port» CLI option
